### PR TITLE
Phalcon 5 update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4",
-        "phalcon/ide-stubs": "^4.0.0",
+        "phalcon/ide-stubs": "^5.0.0",
         "vimeo/psalm": "^4.1",
         "squizlabs/php_codesniffer": "^3.5",
         "codeception/module-phpbrowser": "^1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=7.2",
-        "ext-phalcon": "^4.0.0 || ^5.0.0"
+        "ext-phalcon": "^5.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": ">=7.2",
-        "ext-phalcon": "^4.0.0"
+        "ext-phalcon": "^4.0.0 || ^5.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4",

--- a/src/Traits/FunctionalTestCase.php
+++ b/src/Traits/FunctionalTestCase.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Incubator\Test\Traits;
 
 use Phalcon\Di\DiInterface;
-use Phalcon\Escaper as PhEscaper;
+use Phalcon\Html\Escaper as PhEscaper;
 use Phalcon\Mvc\Application as PhApplication;
 use Phalcon\Mvc\Dispatcher as PhDispatcher;
 

--- a/src/Traits/ModelTestCase.php
+++ b/src/Traits/ModelTestCase.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Incubator\Test\Traits;
 
-use Phalcon\Config;
+use Phalcon\Config\Config;
 use Phalcon\Mvc\Model\Manager as PhModelManager;
 use Phalcon\Mvc\Model\Metadata\Memory as PhMetadataMemory;
 

--- a/src/Traits/UnitTestCase.php
+++ b/src/Traits/UnitTestCase.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Phalcon\Incubator\Test\Traits;
 
-use Phalcon\Config;
-use Phalcon\Di;
+use Phalcon\Config\Config;
+use Phalcon\Di\Di;
 use Phalcon\Di\DiInterface;
-use Phalcon\Escaper;
-use Phalcon\Url;
+use Phalcon\Html\Escaper;
+use Phalcon\Mvc\Url;
 
 trait UnitTestCase
 {


### PR DESCRIPTION
Contains breaking code changes for Phalcon 5. Must be released under new major version. https://docs.phalcon.io/5.0/en/unit-testing points to ^v1.0.0-alpha.1 which is not compatible with Phalcon 5.0